### PR TITLE
Use `vector.zip(...)` instead of `vector.awk(ak.zip(...))`

### DIFF
--- a/13-TeV-examples/uproot_python/HZZAnalysis.ipynb
+++ b/13-TeV-examples/uproot_python/HZZAnalysis.ipynb
@@ -381,7 +381,7 @@
    "source": [
     "def calc_mllll(lep_pt, lep_eta, lep_phi, lep_E):\n",
     "    # construct awkward 4-vector array\n",
-    "    p4 = vector.awk(ak.zip(dict(pt=lep_pt, eta=lep_eta, phi=lep_phi, E=lep_E)))\n",
+    "    p4 = vector.zip({\"pt\": lep_pt, \"eta\": lep_eta, \"phi\": lep_phi, \"E\": lep_E})\n",
     "    # calculate invariant mass of first 4 leptons\n",
     "    # [:, i] selects the i-th lepton in each event\n",
     "    # .M calculates the invariant mass\n",
@@ -811,7 +811,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -825,7 +825,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
`Vector` provides the `zip` constructor that should be used instead of the `vector.awk(ak.zip(...))` call.

The `vector.awk(ak.zip(...))` call can be confusing for beginners, given that the constructors don't perform any typing checks right now, passing the same data directly into `vector.awk(...)` (instead of `ak.zip(...)` and then `vector.awk(...)`) would give no errors. This is a typical situation that a beginner might encounter, leading to very unexpected (unexpected for newcomers) mathematical errors down the code.

For reference, see https://github.com/scikit-hep/vector/discussions/205. The user found out about this constructor issue when they were trying to perform a mathematical operation on the contents of the vector.

cc: @henryiii