### PR TITLE
Adding notebooks automated checks

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -4,12 +4,12 @@ name: Create and publish a Docker image
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     paths:
       - 'Dockerfile'
   pull_request:
     branches:
-      - 'main'
+      - 'master'
     paths:
       - 'Dockerfile'
 

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -7,11 +7,15 @@ on:
       - 'master'
     paths:
       - 'Dockerfile'
+    paths-ignore:
+      - .github/**
   pull_request:
     branches:
       - 'master'
     paths:
       - 'Dockerfile'
+    paths-ignore:
+      - .github/**
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -2,20 +2,11 @@
 name: Create and publish a Docker image
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'Dockerfile'
-    paths-ignore:
-      - .github/**
   pull_request:
     branches:
       - 'master'
     paths:
       - 'Dockerfile'
-    paths-ignore:
-      - .github/**
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -1,0 +1,71 @@
+#
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Dockerfile'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'Dockerfile'
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          flavor: |
+            latest=true
+          tags: |
+            type=sha
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -7,6 +7,7 @@ on:
       - 'master'
     paths:
       - 'Dockerfile'
+      - '.github/workflows/docker_push.yml'
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -55,6 +56,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          visibility: public
       
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
       - name: Generate artifact attestation

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -3,6 +3,11 @@ name: Run Jupyter Notebooks
 on:
   # push:
   pull_request:
+    branches:
+        - 'main'
+    paths-ignore:
+      - 'README.md'
+      - 'Dockerfile'
   schedule:
     - cron: '0 0 1 * *'
 
@@ -118,7 +123,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+          pip install jupyter ipykernel papermill coffea
 
       - name: Set up Jupyter kernel
         run: |
@@ -469,15 +474,11 @@ jobs:
 
           echo "# Status of the Jupyter notebooks" > status.md
           echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions/runs/${{ github.run_id }}).*" >> status.md
-          echo "| Status | Link |" >> status.md
-          echo "|----------|----------|" >> status.md
-          pwd
 
           declare -A notebooks
 
           for file in $(pwd)/artifacts/*/*
           do
-            file $file
             if [ -f "$file" ]; then
               while IFS= read -r line
               do
@@ -491,19 +492,16 @@ jobs:
                 prefix="https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/tree/master/"
                 URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
 
-                # Extract the section title
-                section=$(echo "$NOTEBOOK" | sed -E 's/^.*result_run-notebooks-([^-]+)-([^-]+).*$/\1-\2/')
+                section=$(echo "$NOTEBOOK" | cut -d'-' -f4)
                 
-                # Append notebook info to the corresponding section
                 notebooks["$section"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
               done < $file
             fi
           done
 
-          # Write the sections and notebooks to status.md
           for section in "${!notebooks[@]}"
           do
-            echo "### ${section//-/ }" >> status.md
+            echo "### $section" >> status.md
             echo "| Status | Link |" >> status.md
             echo "|----------|----------|" >> status.md
             echo -e "${notebooks[$section]}" >> status.md

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -287,13 +287,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: Set up Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.8'
-
-
-
+      
       - name: Set up Jupyter kernel
         run: |
           python -m ipykernel install --user --name=python3
@@ -332,13 +326,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: Set up Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.8'
-
-
-
+      
       - name: Set up Jupyter kernel
         run: |
           python -m ipykernel install --user --name=python3
@@ -377,13 +365,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: Set up Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.8'
-
-
-
+      
       - name: Set up Jupyter kernel
         run: |
           python -m ipykernel install --user --name=python3
@@ -504,5 +486,5 @@ jobs:
 
           git checkout -b update_status_${{ github.sha }}
           git add status.md
-          git commit -m "Update status.md"
+          git commit -m "Update status.md, commit ${{ github.sha }}"
           git push -u origin update_status_${{ github.sha }}

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -105,7 +105,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS8_cpp != '[]' }}
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS8_python != '[]' }}
     strategy:
       fail-fast: false
@@ -202,7 +202,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_cpp != '[]' }}
     strategy:
       fail-fast: false
@@ -250,7 +250,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_python != '[]' }}
     strategy:
       fail-fast: false
@@ -298,7 +298,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_uproot != '[]' }}
     strategy:
       fail-fast: false
@@ -346,7 +346,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_rdataframe != '[]' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -430,7 +430,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: result_run-notebooks-research-${{ env.sanitized_name }}.txt
+          name: result_run-notebooks-13-research-${{ env.sanitized_name }}.txt
           path: ./artifacts
 
 
@@ -472,25 +472,43 @@ jobs:
           echo "| Status | Link |" >> status.md
           echo "|----------|----------|" >> status.md
           pwd
+
+          declare -A notebooks
+
           for file in $(pwd)/artifacts/*/*
-            do
-              file $file
-              if [ -f "$file" ]; then
-                while IFS= read -r line
-                do
-                  NOTEBOOK=$(echo "$line" | cut -d: -f1)
-                  STATUS=$(echo "$line" | cut -d: -f2 | xargs)
-                  if [[ "$STATUS" == "success" ]]; then
-                    OUT="✅"
-                  else
-                    OUT="❌"
-                  fi
-                  prefix="https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/tree/master/"
-                  URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
-                  echo "| $OUT | [$(basename $NOTEBOOK)]($URL) |" >> status.md
-                done < $file
-              fi
-            done
+          do
+            file $file
+            if [ -f "$file" ]; then
+              while IFS= read -r line
+              do
+                NOTEBOOK=$(echo "$line" | cut -d: -f1)
+                STATUS=$(echo "$line" | cut -d: -f2 | xargs)
+                if [[ "$STATUS" == "success" ]]; then
+                  OUT="✅"
+                else
+                  OUT="❌"
+                fi
+                prefix="https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/tree/master/"
+                URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
+
+                # Extract the section title
+                section=$(echo "$NOTEBOOK" | sed -E 's/^.*result_run-notebooks-([^-]+)-([^-]+).*$/\1-\2/')
+                
+                # Append notebook info to the corresponding section
+                notebooks["$section"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
+              done < $file
+            fi
+          done
+
+          # Write the sections and notebooks to status.md
+          for section in "${!notebooks[@]}"
+          do
+            echo "### ${section//-/ }" >> status.md
+            echo "| Status | Link |" >> status.md
+            echo "|----------|----------|" >> status.md
+            echo -e "${notebooks[$section]}" >> status.md
+          done
+          echo "*Last update on $(date)*" >> status.md
           cat status.md
 
       - name: Commit and push to GitLab

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -1,0 +1,330 @@
+name: Run Jupyter Notebooks
+
+on:
+  # push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  find-notebooks:
+    runs-on: ubuntu-latest
+    outputs:
+      notebooks: ${{ steps.get-notebooks.outputs.notebooks }}
+      NOTEBOOKS8_cpp: ${{ steps.get-notebooks.outputs.notebooks8-cpp }}
+      NOTEBOOKS8_python: ${{ steps.get-notebooks.outputs.notebooks8-python }}
+      NOTEBOOKS13_cpp: ${{ steps.get-notebooks.outputs.notebooks13-cpp }}
+      NOTEBOOKS13_python: ${{ steps.get-notebooks.outputs.notebooks13-python }}
+      NOTEBOOKS13_uproot: ${{ steps.get-notebooks.outputs.notebooks13-uproot }}
+      NOTEBOOKS13_rdataframe: ${{ steps.get-notebooks.outputs.notebooks13-rdataframe }}
+      NOTEBOOKS_research: ${{ steps.get-notebooks.outputs.notebooks-research }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jq papermill
+
+      - name: Get all notebooks
+        id: get-notebooks
+        run: |
+          {
+          NOTEBOOKS=$(find . -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS="[]"
+          fi
+          
+          NOTEBOOKS8_cpp=$(find ./8-TeV-examples/cpp -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS8_cpp" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS8_cpp="[]"
+          fi
+          echo "notebooks8-cpp=$NOTEBOOKS8_cpp" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS8_python=$(find ./8-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS8_python" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS8_python="[]"
+          fi
+          echo "notebooks8-python=$NOTEBOOKS8_python" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS13_cpp=$(find ./13-TeV-examples/cpp -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS13_cpp" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS13_cpp="[]"
+          fi
+          echo "notebooks13-cpp=$NOTEBOOKS13_cpp" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS13_uproot=$(find ./13-TeV-examples/uproot_python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS13_uproot" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS13_uproot="[]"
+          fi
+          echo "notebooks13-uproot=$NOTEBOOKS13_uproot" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS13_python=$(find ./13-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS13_python" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS13_python="[]"
+          fi
+          echo "notebooks13-python=$NOTEBOOKS13_python" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS13_rdataframe=$(find ./13-TeV-examples/rdataframe -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS13_rdataframe" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS13_rdataframe="[]"
+          fi
+          echo "notebooks13-rdataframe=$NOTEBOOKS13_rdataframe" >> $GITHUB_OUTPUT
+
+          NOTEBOOKS_research=$(find ./for-research -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          if [ -z "$NOTEBOOKS_research" ]; then
+            echo "No notebooks found"
+            NOTEBOOKS_research="[]"
+          fi
+          echo "notebooks-research=$NOTEBOOKS_research" >> $GITHUB_OUTPUT
+          
+          cat $GITHUB_OUTPUT
+          echo "Got all notebooks!"
+          }
+
+  run-notebooks-8-cpp:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS8_cpp != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS8_cpp) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=root
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+
+  run-notebooks-8-python:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS8_python != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS8_python) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11.6'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=python3
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+  run-notebooks-13-cpp:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_cpp != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS13_cpp) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11.6'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=root
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+
+  run-notebooks-13-python:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_python != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS13_python) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11.6'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=python3
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+  run-notebooks-13-uproot:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_uproot != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS13_uproot) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=python3
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+  run-notebooks-13-rdataframe:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS13_rdataframe != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS13_rdataframe) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=python3
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+  run-notebooks-research:
+    needs: find-notebooks
+    runs-on: ubuntu-22.04
+    container:
+      image: atlasopendata/root_notebook:codata22
+    if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS_research != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook: ${{ fromJson(needs.find-notebooks.outputs.NOTEBOOKS_research) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel papermill
+
+      - name: Set up Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name=python3
+
+      - name: Run notebook with Papermill
+        run: |
+          cd $(dirname ${{ matrix.notebook }})
+          papermill $(basename ${{ matrix.notebook }}) /dev/null

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -1,7 +1,7 @@
 name: Run Jupyter Notebooks
 
 on:
-  # push:
+  push:
   pull_request:
   schedule:
     - cron: '0 0 1 * *'
@@ -129,6 +129,21 @@ jobs:
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
 
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-8-cpp-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-8-cpp-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-8-cpp-${{ env.sanitized_name }}.txt
+          path: ./artifacts
+
 
   run-notebooks-8-python:
     needs: find-notebooks
@@ -163,6 +178,21 @@ jobs:
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
 
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-8-python-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-8-python-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-8-python-${{ env.sanitized_name }}.txt
+          path: ./artifacts
+
   run-notebooks-13-cpp:
     needs: find-notebooks
     runs-on: ubuntu-22.04
@@ -196,6 +226,20 @@ jobs:
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
 
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-13-cpp-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-13-cpp-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-13-cpp-${{ env.sanitized_name }}.txt
+          path: ./artifacts
 
   run-notebooks-13-python:
     needs: find-notebooks
@@ -230,6 +274,21 @@ jobs:
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
 
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-13-python-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-13-python-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-13-python-${{ env.sanitized_name }}.txt
+          path: ./artifacts
+
   run-notebooks-13-uproot:
     needs: find-notebooks
     runs-on: ubuntu-22.04
@@ -262,6 +321,21 @@ jobs:
         run: |
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-13-uproot-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-13-uproot-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-13-uproot-${{ env.sanitized_name }}.txt
+          path: ./artifacts
 
   run-notebooks-13-rdataframe:
     needs: find-notebooks
@@ -296,6 +370,21 @@ jobs:
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
 
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-13-rdataframe-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-13-rdataframe-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-13-rdataframe-${{ env.sanitized_name }}.txt
+          path: ./artifacts
+
   run-notebooks-research:
     needs: find-notebooks
     runs-on: ubuntu-22.04
@@ -328,3 +417,97 @@ jobs:
         run: |
           cd $(dirname ${{ matrix.notebook }})
           papermill $(basename ${{ matrix.notebook }}) /dev/null
+
+      - name: Output result
+        if: always()
+        run: |
+          mkdir -p ./artifacts
+          echo "${{ matrix.notebook }}: ${{ job.status }}" >> ./artifacts/result_run-notebooks-research-$(basename ${{ matrix.notebook }}).txt
+          cat ./artifacts/result_run-notebooks-research-$(basename ${{ matrix.notebook }}).txt
+          echo "sanitized_name=$(basename ${{ matrix.notebook }})" >> $GITHUB_ENV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: result_run-notebooks-research-${{ env.sanitized_name }}.txt
+          path: ./artifacts
+
+
+
+  generate-status-report:
+    runs-on: ubuntu-latest
+    needs: [run-notebooks-8-cpp,run-notebooks-8-python,run-notebooks-13-cpp,run-notebooks-13-python,run-notebooks-13-uproot,run-notebooks-13-rdataframe,run-notebooks-research]
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create downloaded-artifacts directory
+        run: mkdir -p ./artifacts
+
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts
+      
+      - name: Generate status report
+        run: |
+          echo "# Notebook Run Status" > status.md
+          echo "" >> status.md
+
+          JOB_FILES=(
+            "result_run-notebooks-8-cpp.txt"
+            "result_run-notebooks-8-python.txt"
+            "result_run-notebooks-13-cpp.txt"
+            "result_run-notebooks-13-python.txt"
+            "result_run-notebooks-13-uproot.txt"
+            "result_run-notebooks-13-rdataframe.txt"
+            "result_run-notebooks-research.txt"
+          )
+
+          echo "| Status | Link |" > status.md
+          echo "|----------|----------|" >> status.md
+          pwd
+          for file in $(pwd)/artifacts/*/*
+            do
+              file $file
+              if [ -f "$file" ]; then
+                while IFS= read -r line
+                do
+                  NOTEBOOK=$(echo "$line" | cut -d: -f1)
+                  STATUS=$(echo "$line" | cut -d: -f2 | xargs)
+                  if [[ "$STATUS" == "success" ]]; then
+                    OUT="✅"
+                  else
+                    OUT="❌"
+                  fi
+                  prefix="https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/tree/master/"
+                  URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
+                  echo "| $OUT | [$(basename $NOTEBOOK)]($URL) |" >> status.md
+                done < $file
+              fi
+            done
+          cat status.md
+
+      - name: Commit and push to GitLab
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          GITLAB_USER: ${{ secrets.GITLAB_USER }}
+        run: |
+          git config --global user.name "${GITLAB_USER}"
+          git config --global user.email "${GITLAB_USER}@cern.ch"
+          
+          git clone https://oauth2:${GITLAB_TOKEN}@gitlab.cern.ch/atlas-outreach-data-tools/atlas-open-data-website-v2.git
+          git remote set-url origin https://oauth2:${GITLAB_TOKEN}@gitlab.cern.ch/atlas-outreach-data-tools/atlas-open-data-website-v2.git
+          cd atlas-open-data-website-v2/docs
+          
+          mv ../../status.md status.md
+
+          ls -l status.md
+
+          git checkout -b update_status_${{ github.sha }}
+          git add status.md
+          git commit -m "Update status.md"
+          git push -u origin update_status_${{ github.sha }}

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -468,7 +468,7 @@ jobs:
           )
 
           echo "# Status of the Jupyter notebooks" > status.md
-          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions).*" >> status.md
+          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions/runs/${{ github.run_number }}).*" >> status.md
           echo "| Status | Link |" >> status.md
           echo "|----------|----------|" >> status.md
           pwd

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -55,7 +55,7 @@ jobs:
           fi
           echo "notebooks8-cpp=$NOTEBOOKS8_cpp" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS8_python=$(find ./8-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS8_python=$(find ./8-TeV-examples/python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS8_python" ]; then
             echo "No notebooks found"
             NOTEBOOKS8_python="[]"
@@ -69,14 +69,14 @@ jobs:
           fi
           echo "notebooks13-cpp=$NOTEBOOKS13_cpp" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS13_uproot=$(find ./13-TeV-examples/uproot_python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS13_uproot=$(find ./13-TeV-examples/uproot_python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS13_uproot" ]; then
             echo "No notebooks found"
             NOTEBOOKS13_uproot="[]"
           fi
           echo "notebooks13-uproot=$NOTEBOOKS13_uproot" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS13_python=$(find ./13-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS13_python=$(find ./13-TeV-examples/python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS13_python" ]; then
             echo "No notebooks found"
             NOTEBOOKS13_python="[]"
@@ -492,7 +492,7 @@ jobs:
                 prefix="https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/tree/master/"
                 URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
 
-                section=$(echo "$NOTEBOOK" | cut -d'-' -f4)
+                section=$(echo "$NOTEBOOK" | cut -d'/' -f3)
                 
                 notebooks["$section"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
               done < $file

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -4,7 +4,7 @@ on:
   # push:
   pull_request:
     branches:
-        - 'main'
+        - 'master'
     paths-ignore:
       - 'README.md'
       - 'Dockerfile'

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -468,8 +468,8 @@ jobs:
           )
 
           echo "# Status of the Jupyter notebooks" > status.md
-          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions).*" > status.md
-          echo "| Status | Link |" > status.md
+          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions).*" >> status.md
+          echo "| Status | Link |" >> status.md
           echo "|----------|----------|" >> status.md
           pwd
           for file in $(pwd)/artifacts/*/*

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -1,7 +1,7 @@
 name: Run Jupyter Notebooks
 
 on:
-  push:
+  # push:
   pull_request:
   schedule:
     - cron: '0 0 1 * *'
@@ -467,6 +467,8 @@ jobs:
             "result_run-notebooks-research.txt"
           )
 
+          echo "# Status of the Jupyter notebooks" > status.md
+          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions).*" > status.md
           echo "| Status | Link |" > status.md
           echo "|----------|----------|" >> status.md
           pwd

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -468,7 +468,7 @@ jobs:
           )
 
           echo "# Status of the Jupyter notebooks" > status.md
-          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions/runs/${{ github.run_number }}).*" >> status.md
+          echo "*This page is created automatically, for more information please visit [our repository](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/actions/runs/${{ github.run_id }}).*" >> status.md
           echo "| Status | Link |" >> status.md
           echo "|----------|----------|" >> status.md
           pwd

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -55,7 +55,7 @@ jobs:
           fi
           echo "notebooks8-cpp=$NOTEBOOKS8_cpp" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS8_python=$(find ./8-TeV-examples/python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS8_python=$(find ./8-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS8_python" ]; then
             echo "No notebooks found"
             NOTEBOOKS8_python="[]"
@@ -69,14 +69,14 @@ jobs:
           fi
           echo "notebooks13-cpp=$NOTEBOOKS13_cpp" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS13_uproot=$(find ./13-TeV-examples/uproot_python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS13_uproot=$(find ./13-TeV-examples/uproot_python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS13_uproot" ]; then
             echo "No notebooks found"
             NOTEBOOKS13_uproot="[]"
           fi
           echo "notebooks13-uproot=$NOTEBOOKS13_uproot" >> $GITHUB_OUTPUT
 
-          NOTEBOOKS13_python=$(find ./13-TeV-examples/python -name '*Z.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
+          NOTEBOOKS13_python=$(find ./13-TeV-examples/python -name '*.ipynb' -print0 | jq -Rsc 'split("\u0000")[:-1]')
           if [ -z "$NOTEBOOKS13_python" ]; then
             echo "No notebooks found"
             NOTEBOOKS13_python="[]"
@@ -394,7 +394,7 @@ jobs:
     needs: find-notebooks
     runs-on: ubuntu-22.04
     container:
-      image: atlasopendata/root_notebook:codata22
+      image: ghcr.io/atlas-outreach-data-tools/notebooks-collection-opendata:latest
     if: ${{ needs.find-notebooks.result == 'success' && needs.find-notebooks.outputs.NOTEBOOKS_research != '[]' }}
     strategy:
       fail-fast: false
@@ -493,8 +493,15 @@ jobs:
                 URL=$(echo "${NOTEBOOK/\.\//"$prefix"}")
 
                 section=$(echo "$NOTEBOOK" | cut -d'/' -f3)
-                
-                notebooks["$section"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
+                if [[ "$section" == "uproot_python" ]]; then
+                  notebooks["uproot"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
+                elif [[ "$section" == "rdataframe" ]]; then
+                  echo "yoooo"
+                  notebooks["RDataFrame"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
+                else
+                  notebooks["$section"]+="$OUT|[$(basename $NOTEBOOK)]($URL)\n"
+                fi
+
               done < $file
             fi
           done
@@ -506,7 +513,7 @@ jobs:
             echo "|----------|----------|" >> status.md
             echo -e "${notebooks[$section]}" >> status.md
           done
-          echo "*Last update on $(date)*" >> status.md
+          echo "*Last update on $(TZ=Europe/Rome date)*" >> status.md
           cat status.md
 
       - name: Commit and push to GitLab

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -33,11 +33,6 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jq papermill
-
       - name: Get all notebooks
         id: get-notebooks
         run: |
@@ -120,11 +115,6 @@ jobs:
       #   with:
       #     python-version: '3.8'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill coffea
-
       - name: Set up Jupyter kernel
         run: |
           python -m ipykernel install --user --name=root
@@ -169,11 +159,6 @@ jobs:
       #   with:
       #     python-version: '3.11.6'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
-
       - name: Set up Jupyter kernel
         run: |
           python -m ipykernel install --user --name=python3
@@ -217,10 +202,7 @@ jobs:
       #   with:
       #     python-version: '3.11.6'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+
 
       - name: Set up Jupyter kernel
         run: |
@@ -265,10 +247,7 @@ jobs:
       #   with:
       #     python-version: '3.11.6'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+
 
       - name: Set up Jupyter kernel
         run: |
@@ -313,10 +292,7 @@ jobs:
       #   with:
       #     python-version: '3.8'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+
 
       - name: Set up Jupyter kernel
         run: |
@@ -361,10 +337,7 @@ jobs:
       #   with:
       #     python-version: '3.8'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+
 
       - name: Set up Jupyter kernel
         run: |
@@ -409,10 +382,7 @@ jobs:
       #   with:
       #     python-version: '3.8'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install jupyter ipykernel papermill
+
 
       - name: Set up Jupyter kernel
         run: |

--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -8,8 +8,9 @@ on:
     paths-ignore:
       - 'README.md'
       - 'Dockerfile'
+      - '.github/workflows/docker_push.yml'
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 0 * * 3'
 
 jobs:
   find-notebooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM jupyter/scipy-notebook:x86_64-ubuntu-22.04
+LABEL maintainer="giovanni.guerrieri@cern.ch"
+WORKDIR /
+ENV DEBIAN_FRONTEND=noninteractive
+USER root
+
+#install the prerequisites (option always yes activated)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y python3 python3-dev git curl python3-pip \                                           
+    && apt-get --yes install \
+    dpkg-dev  \
+    cmake \
+    g++ \
+    gcc \
+    binutils\
+    libx11-dev\
+    libxpm-dev\
+    libxft-dev\
+    libxext-dev\
+    libssl-dev\
+    nano\
+    vim
+
+RUN conda update \
+jupyterlab \
+notebook
+
+#    ========================== 
+#    Installing ROOT 
+#    ========================== 
+RUN conda install root -c conda-forge
+
+RUN pip3 install --no-cache-dir --upgrade  \
+    uproot3 \
+    uproot \
+    tables \
+    matplotlib \
+    pydot \
+    awkward==1.2.0 \
+    vector \
+    scikit-learn \
+    lmfit \
+    jupyter \ 
+    ipykernel \ 
+    papermill \
+    coffea
+
+
+WORKDIR /home/jovyan/work/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,14 @@ RUN pip3 install --no-cache-dir --upgrade  \
     pandas \
     pydot \
     awkward \
+    awkward-pandas \
     vector \
     scikit-learn \
     lmfit \
     jupyter \ 
     ipykernel \ 
     papermill \
+    dask[distributed] \
     coffea
 
 WORKDIR /home/jovyan/work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook:x86_64-ubuntu-22.04
+FROM rootproject/root:6.32.02-ubuntu22.04
 LABEL maintainer="giovanni.guerrieri@cern.ch"
 WORKDIR /
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,43 +9,26 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y python3 python3-dev git curl python3-pip \                                           
     && apt-get --yes install \
-    dpkg-dev  \
-    cmake \
-    g++ \
-    gcc \
-    binutils\
-    libx11-dev\
-    libxpm-dev\
-    libxft-dev\
-    libxext-dev\
-    libssl-dev\
     nano\
     vim
 
-RUN conda update \
-jupyterlab \
-notebook
-
-#    ========================== 
-#    Installing ROOT 
-#    ========================== 
-RUN conda install root -c conda-forge
 
 RUN pip3 install --no-cache-dir --upgrade  \
     uproot3 \
     uproot \
     tables \
     matplotlib \
+    pandas \
     pydot \
-    awkward==1.2.0 \
+    awkward \
     vector \
     scikit-learn \
     lmfit \
     jupyter \ 
     ipykernel \ 
     papermill \
+    sklearn \
     coffea
-
 
 WORKDIR /home/jovyan/work/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN pip3 install --no-cache-dir --upgrade  \
     jupyter \ 
     ipykernel \ 
     papermill \
-    sklearn \
     coffea
 
 WORKDIR /home/jovyan/work/


### PR DESCRIPTION
## Adding an automated notebook check using papermill
Scheduling check every first day of the month or on PR.

Tracking JIRA issue [MYATLAS-150](https://its.cern.ch/jira/browse/MYATLAS-150).

### Description

Notebooks are automatically detected and grouped by folder/category (cpp, python, uproot, research, etc.), then executed via [papermill](https://papermill.readthedocs.io/en/latest/).

A **_status page_** with a summary of which notebooks are working and which are not is created and pushed (right now in a branch different than master) to the Open Data website.
[Example here](https://gitlab.cern.ch/atlas-outreach-data-tools/atlas-open-data-website-v2/-/blob/edf1697452f192ab9d8038df445b76accf70a788/docs/status.md)

### Specs

Currently using ~[`atlasopendata/root_notebook:codata22`](https://hub.docker.com/layers/atlasopendata/root_notebook/codata22/images/sha256-8448c4e8cff1974defa90f8fb33030c15153c7d9a38402c9619de5046c708e5a?context=explore)~ [`notebooks-collection-opendata`](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/pkgs/container/notebooks-collection-opendata) as base image for running all the notebooks.

### TODOs

- [ ] Create a list of notebooks to be ignored (e.g. the ones that require the user to complete certain cells)
- [x] Create a Dockerfile and a workflow dedicated to the image used in the notebooks.
- [x] Decide whether we want to publish the status page automatically via git push ~or if we want to open a MR to the website repo with each update~.

Tagging @marianaiv, @zlmarshall, @AntonioJC, @artfisica as reviewers. 
Suggestions/modifications are very welcome.