### PR TITLE
Make papermill only output errors (and worse)

### DIFF
--- a/.github/workflows/notebooks-runner-autocheck.yml
+++ b/.github/workflows/notebooks-runner-autocheck.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Run notebook with Papermill
         run: |
           cd $(dirname ${{ matrix.notebook }})
-          papermill $(basename ${{ matrix.notebook }}) /dev/null
+          papermill --log-level ERROR $(basename ${{ matrix.notebook }}) /dev/null
 
       - name: Output result
         if: always()


### PR DESCRIPTION
Since we're "only" using papermill to check that the notebooks run, we can ask it to ignore warnings. This will get rid of the warnings in the current CI from piping to /dev/null. See also:

https://github.com/nteract/papermill/issues/446