### PR TITLE
Fix: bumping python version and relaxing package version criteria

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,27 +2,27 @@ name: analysis
 channels:
     - conda-forge
 dependencies:
-  - python=3.10
-  - aiohttp==3.9.5
-  - awkward==2.6.7
-  - awkward-pandas==2023.8.0
-  - coffea==0.7.0
-  - dask[distributed]==2024.8.2
-  - hist==2.8.0
-  - ipykernel==6.29.5
-  - jupyter==1.0.0
-  - libmamba==2.0.4
-  - lmfit==1.3.2
-  - matplotlib==3.9.1
-  - metakernel==0.30.2
-  - numpy==1.26.4
-  - pandas==2.2.2
-  - papermill==2.6.0
-  - pip==24.2
-  - root_base==6.32.2
-  - scikit-learn==1.5.1
-  - uproot==5.3.10
-  - uproot3==3.14.4
+  - python=3.11
+  - aiohttp>=3.9.5
+  - awkward>=2.6.7
+  - awkward-pandas>=2023.8.0
+  - coffea>=0.7.0
+  - dask[distributed]>=2024.8.2
+  - hist>=2.8.0
+  - ipykernel>=6.29.5
+  - jupyter>=1.0.0
+  - libmamba>=2.0.4
+  - lmfit>=1.3.2
+  - matplotlib>=3.9.1
+  - metakernel>=0.30.2
+  - numpy>=1.26.4
+  - pandas>=2.2.2
+  - papermill>=2.6.0
+  - pip>=24.2
+  - root_base>=6.32.2
+  - scikit-learn>=1.5.1
+  - uproot>=5.3.10
+  - uproot3>=3.14.4
   - pip:
-    - jupyterlab_latex==3.1.0
-    - vector==1.4.1
+    - jupyterlab_latex>=3.1.0
+    - vector>=1.4.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - aiohttp>=3.9.5
   - awkward>=2.6.7
   - awkward-pandas>=2023.8.0
-  - coffea>=0.7.0
+  - coffea~=0.7.0
   # - dask[distributed]>=2025.2.0
   - hist>=2.8.0
   - ipykernel>=6.29.5

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - awkward>=2.6.7
   - awkward-pandas>=2023.8.0
   - coffea>=0.7.0
-  - dask[distributed]>=2024.8.2
+  # - dask[distributed]>=2025.2.0
   - hist>=2.8.0
   - ipykernel>=6.29.5
   - jupyter>=1.0.0


### PR DESCRIPTION
### Description 
Relaxing package version requirements in order to let `libmamba` find compatibilities.

- [x] Local [`repo2docker`](https://jupyter.org/binder#repo2docker) build passes
- [x] Docker build passes
- [x] Notebooks run with current "relaxed" packages versions

### Reproducibility steps
In order to install and test the binder env:
```sh
python -m venv env
source env/bin/activate
pip install jupyter-repo2docker
repo2docker .
```
This needs Docker to be installed!