### PR TITLE
Bugs phoenix script

### DIFF
--- a/for-research/phoenix/get_json_phoenix.py
+++ b/for-research/phoenix/get_json_phoenix.py
@@ -498,6 +498,7 @@ def json_format(files: list[str],
 
             # Add e/gamma clusters in preparation for photons and electrons
             this_event['CaloClusters'] = {}
+            this_event['CaloClusters']['egammaClusters'] = []
             if not ntuple:
                 if 'egammaClusters' in events_data.fields:
                     this_event['CaloClusters']['egammaClusters'] = []


### PR DESCRIPTION
Trying to fix the phoenix script to work with PHYSLITE/HION14/E&O 13TeV beta release.

So far it was missing a line to work with ntuples, but I am still getting an error with a skimmed one:

```bash
UserWarning: Skipping n_sig_ph as it is not interpretable by Uproot
  warnings.warn(f"Skipping {key} as it is not interpretable by Uproot")
```
  
  No clue what this is about. Left examples of a json file for each for double checking things make sense (hion14, physlite and a E&O noskim mc). 20 events each.
  
- [himc.json](https://github.com/user-attachments/files/20911443/himc.json)
- [physlite.json](https://github.com/user-attachments/files/20911448/physlite.json)
- [eonoskim.json](https://github.com/user-attachments/files/20911462/eonoskim.json)