### PR TITLE
Metadata tutorial

### DIFF
--- a/13-TeV-examples/uproot_python/MetadataTutorial.ipynb
+++ b/13-TeV-examples/uproot_python/MetadataTutorial.ipynb
@@ -1,0 +1,340 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3b02359c",
+   "metadata": {},
+   "source": [
+    "# Metadata in ATLAS Open Data\n",
+    "\n",
+    "All datasets have associated metadata -- properties shared by all the events in the dataset. In the ATLAS Open Data, metadata includes things like a unique numerical dataset identifier, the production cross section, and the description of the physics processes included in the sample. These metadata must be used to properly normalize the MC simulation datasets when comparing to detector data, and they can also be used to search for related samples.\n",
+    "\n",
+    "The metadata are available in a package called `atlasopenmagic` that is [available on pypi](http://pypi.org/project/atlasopenmagic/). Let's set it up and use it to explore the metadata of the most recent ATLAS Open Data release!\n",
+    "\n",
+    "Note that the metadata we will be looking at are also [available on the web](https://opendata.atlas.cern/docs/data/for_education/13TeV25_metadata) in a big table, but using a python module will make it much easier to grab numbers that you need for an analysis in an automatic way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "572b491f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting atlasopenmagic\n",
+      "  Using cached atlasopenmagic-1.0.1-py3-none-any.whl.metadata (7.2 kB)\n",
+      "Requirement already satisfied: pyyaml in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from atlasopenmagic) (6.0.1)\n",
+      "Requirement already satisfied: requests in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from atlasopenmagic) (2.31.0)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (2.0.6)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (3.2)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (1.26.16)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (2022.12.7)\n",
+      "Using cached atlasopenmagic-1.0.1-py3-none-any.whl (15 kB)\n",
+      "Installing collected packages: atlasopenmagic\n",
+      "Successfully installed atlasopenmagic-1.0.1\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# First we install atlasopenmagic into our SWAN environment\n",
+    "# Notice that we need --user to avoid trying to install the package in a read-only file system\n",
+    "# This is a problem unique to SWAN; on binder or colab you won't need --user\n",
+    "%pip install --user atlasopenmagic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0769168a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now we have to do a little bit of work to make sure that atlasopenmagic is available in our python path\n",
+    "# This is because SWAN by default does not include the local package installation area in the PYTHONPATH\n",
+    "# Again, this is not necessary on binder or colab\n",
+    "import sys\n",
+    "import os\n",
+    "sys.path += [ f'{os.environ[\"HOME\"]}/.local/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages' ]\n",
+    "\n",
+    "# Now we can safely import atlasopenmagic\n",
+    "import atlasopenmagic as atom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c229d2f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available releases:\n",
+      "========================================\n",
+      "2016e-8tev        2016 Open Data for education release of 8 TeV proton-proton collisions (https://opendata.cern.ch/record/3860).\n",
+      "2020e-13tev       2020 Open Data for education release of 13 TeV proton-proton collisions (https://cern.ch/2r7xt).\n",
+      "2024r-pp          2024 Open Data for research release for proton-proton collisions (https://opendata.cern.record/80020).\n",
+      "2024r-hi          2024 Open Data for research release for heavy-ion collisions (https://opendata.cern.ch/record/80035).\n",
+      "2025e-13tev-beta  2025 Open Data for education and outreach beta release for 13 TeV proton-proton collisions (https://opendata.cern.ch/record/93910).\n",
+      "2025r-evgen       2025 Open Data for research release for event generation (https://opendata.cern.ch/record/160000).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Now let's see what releases are available to us\n",
+    "atom.available_releases()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9f21e676",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Active release set to: 2025e-13tev-beta. Metadata cache cleared.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And let's plan to use the latest release of Open Data for Outreach and Education\n",
+    "atom.set_release('2025e-13tev-beta')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bbb13de3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fetching and caching all metadata for release: 2025e-13tev-beta...\n",
+      "Successfully cached 374 datasets.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'dataset_number': '345060',\n",
+       " 'physics_short': 'PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l',\n",
+       " 'e_tag': 'e7735',\n",
+       " 'cross_section_pb': 28.3,\n",
+       " 'genFiltEff': 0.000124,\n",
+       " 'kFactor': 1.717,\n",
+       " 'nEvents': 1598000,\n",
+       " 'sumOfWeights': 45231011.19517517,\n",
+       " 'sumOfWeightsSquared': 1296676130.5944173,\n",
+       " 'process': 'ggH H->ZZ->llll',\n",
+       " 'generator': 'Powheg+Pythia8(v.230)+EvtGen(v.1.6.0)',\n",
+       " 'keywords': ['Higgs', 'SM', 'SMHiggs', 'ZZ', 'mH125'],\n",
+       " 'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.noskim.root'],\n",
+       " 'description': '125 GeV',\n",
+       " 'job_path': 'https://gitlab.cern.ch/atlas-physics/pmg/infrastructure/mc15joboptions/-/tree/master/share/DSID345xxx/MC15.345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.py',\n",
+       " 'CoMEnergy': None,\n",
+       " 'GenEvents': None,\n",
+       " 'GenTune': None,\n",
+       " 'PDF': None,\n",
+       " 'Release': None,\n",
+       " 'Filters': None,\n",
+       " 'release': {'name': '2025e-13tev-beta'},\n",
+       " 'skims': [{'skim_type': '2J2LMET30',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2J2LMET30.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14667,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '1LMET30',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.1LMET30.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14668,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '3J1LMET30',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3J1LMET30.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14669,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': 'exactly4lep',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly4lep.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14670,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '2muons',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2muons.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14671,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '2to4lep',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2to4lep.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14672,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '4lep',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.4lep.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14673,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': 'exactly3lep',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly3lep.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14674,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': 'GamGam',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.GamGam.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14675,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '3lep',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3lep.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14676,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'},\n",
+       "  {'skim_type': '2bjets',\n",
+       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2bjets70.root'],\n",
+       "   'description': None,\n",
+       "   'id': 14677,\n",
+       "   'dataset_number': '345060',\n",
+       "   'release_name': '2025e-13tev-beta'}]}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now we can look at the metadata for a specific sample\n",
+    "atom.get_metadata(345060)\n",
+    "# Notice that the function here will accept either the dataset identifier or the \"physics short\", a short unique descriptor for the sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "504f4e2c",
+   "metadata": {},
+   "source": [
+    "That's a lot of metadata! Let's go through the fields a bit:\n",
+    "\n",
+    "* `dataset_number`: Unique identifier assigned to each dataset.\n",
+    "* `physics_short`: Short name with information regarding the content of the dataset.\n",
+    "* `cross_section_pb`: Represents the probability of a particular interaction occurring, measured in picobarns (pb). It is a fundamental parameter that helps understanding the likelihood of specific particle interactions under given conditions.\n",
+    "* `genFiltEff`: Measure of the effectiveness of the selection criteria applied to the data. It indicates the fraction of events that pass the filters applied during the data processing stages.\n",
+    "* `kFactor`: Multiplicative correction factor used to account for higher-order effects in theoretical calculations. It adjusts the leading-order theoretical predictions to better match the observed data by incorporating next-to-leading order (NLO) or next-to-next-to-leading order (NNLO) corrections.\n",
+    "* `nEvents`: Total count of the events in the (unskimmed) dataset.\n",
+    "* `sumOfWeights` (`sumOfWeightsSquared`): Sum of the event weights (or event weights squared) in the released dataset. Use this for normalization of the samples (for understanding the statistical power of the dataset).\n",
+    "* `generator`: Specifies the simulation software used to generate the data. Information about the generators can be found in the Simulation Tools section.\n",
+    "* `keywords`: Terms or phrases associated with the dataset that help to find specific datasets.\n",
+    "* `process`: Brief description of the physics process being studied. For instance, \"H->γγ\" denotes the Higgs boson decaying into two photons.\n",
+    "* `job_path`: Link to the specific code or configuration files used to generate the sample. Sometimes these will be fairly easy to understand; in some cases they are quite complex and difficult for non-experts to understand.\n",
+    "* `description`: Longer description of the process that was generated to create the sample.\n",
+    "* `e_tag`: ATLAS software configuration (including software version) that was used to create the sample.\n",
+    "* `file_list`: The list of paths for the unskimmed files in the dataset. \n",
+    "* `skims`: The list of metadata for the skimmed files in the dataset. Only one skimmed or unskimmed version should be used at a time. Within the skims we have:\n",
+    "   * A file list for the skim.\n",
+    "   * The name of the skim. The exact selections are [described here](https://opendata.atlas.cern/docs/data/for_education/13TeV25_details)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7bcb845b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "28.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get an individual field of metadata\n",
+    "xsec = atom.get_metadata('345060', 'cross_section_pb')\n",
+    "print(xsec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b70b245",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Keywords are a great way to find datasets that you're interested in. Let's see what keywords are available.\n",
+    "atom.available_keywords()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3eeade9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now let's find datasets that match one of those keywords\n",
+    "atom.match_metadata(field='keywords',value='Higgs')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef6bcbe",
+   "metadata": {},
+   "source": [
+    "The [atlasopenmagic documentation](https://pypi.org/project/atlasopenmagic/) has many more examples of searches; please feel free to play with the package yoourself, and [open an issue](https://github.com/atlas-outreach-data-tools/atlasopenmagic/issues) or a [pull request](https://github.com/atlas-outreach-data-tools/atlasopenmagic/pulls) if there is a feature that you would like to have available!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d80e33c7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "@webio": {
+   "lastCommId": null,
+   "lastKernelId": null
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/13-TeV-examples/uproot_python/MetadataTutorial.ipynb
+++ b/13-TeV-examples/uproot_python/MetadataTutorial.ipynb
@@ -1,340 +1,249 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "3b02359c",
-   "metadata": {},
-   "source": [
-    "# Metadata in ATLAS Open Data\n",
-    "\n",
-    "All datasets have associated metadata -- properties shared by all the events in the dataset. In the ATLAS Open Data, metadata includes things like a unique numerical dataset identifier, the production cross section, and the description of the physics processes included in the sample. These metadata must be used to properly normalize the MC simulation datasets when comparing to detector data, and they can also be used to search for related samples.\n",
-    "\n",
-    "The metadata are available in a package called `atlasopenmagic` that is [available on pypi](http://pypi.org/project/atlasopenmagic/). Let's set it up and use it to explore the metadata of the most recent ATLAS Open Data release!\n",
-    "\n",
-    "Note that the metadata we will be looking at are also [available on the web](https://opendata.atlas.cern/docs/data/for_education/13TeV25_metadata) in a big table, but using a python module will make it much easier to grab numbers that you need for an analysis in an automatic way."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "572b491f",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting atlasopenmagic\n",
-      "  Using cached atlasopenmagic-1.0.1-py3-none-any.whl.metadata (7.2 kB)\n",
-      "Requirement already satisfied: pyyaml in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from atlasopenmagic) (6.0.1)\n",
-      "Requirement already satisfied: requests in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from atlasopenmagic) (2.31.0)\n",
-      "Requirement already satisfied: charset_normalizer<4,>=2 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (2.0.6)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (3.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (1.26.16)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /cvmfs/sft.cern.ch/lcg/views/LCG_107_swan/x86_64-el9-gcc13-opt/lib/python3.11/site-packages (from requests->atlasopenmagic) (2022.12.7)\n",
-      "Using cached atlasopenmagic-1.0.1-py3-none-any.whl (15 kB)\n",
-      "Installing collected packages: atlasopenmagic\n",
-      "Successfully installed atlasopenmagic-1.0.1\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# First we install atlasopenmagic into our SWAN environment\n",
-    "# Notice that we need --user to avoid trying to install the package in a read-only file system\n",
-    "# This is a problem unique to SWAN; on binder or colab you won't need --user\n",
-    "%pip install --user atlasopenmagic"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "0769168a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Now we have to do a little bit of work to make sure that atlasopenmagic is available in our python path\n",
-    "# This is because SWAN by default does not include the local package installation area in the PYTHONPATH\n",
-    "# Again, this is not necessary on binder or colab\n",
-    "import sys\n",
-    "import os\n",
-    "sys.path += [ f'{os.environ[\"HOME\"]}/.local/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages' ]\n",
-    "\n",
-    "# Now we can safely import atlasopenmagic\n",
-    "import atlasopenmagic as atom"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "c229d2f2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Available releases:\n",
-      "========================================\n",
-      "2016e-8tev        2016 Open Data for education release of 8 TeV proton-proton collisions (https://opendata.cern.ch/record/3860).\n",
-      "2020e-13tev       2020 Open Data for education release of 13 TeV proton-proton collisions (https://cern.ch/2r7xt).\n",
-      "2024r-pp          2024 Open Data for research release for proton-proton collisions (https://opendata.cern.record/80020).\n",
-      "2024r-hi          2024 Open Data for research release for heavy-ion collisions (https://opendata.cern.ch/record/80035).\n",
-      "2025e-13tev-beta  2025 Open Data for education and outreach beta release for 13 TeV proton-proton collisions (https://opendata.cern.ch/record/93910).\n",
-      "2025r-evgen       2025 Open Data for research release for event generation (https://opendata.cern.ch/record/160000).\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Now let's see what releases are available to us\n",
-    "atom.available_releases()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "9f21e676",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Active release set to: 2025e-13tev-beta. Metadata cache cleared.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# And let's plan to use the latest release of Open Data for Outreach and Education\n",
-    "atom.set_release('2025e-13tev-beta')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "bbb13de3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fetching and caching all metadata for release: 2025e-13tev-beta...\n",
-      "Successfully cached 374 datasets.\n"
-     ]
+      "cell_type": "markdown",
+      "id": "3b02359c",
+      "metadata": {
+        "id": "3b02359c"
+      },
+      "source": [
+        "# Metadata in ATLAS Open Data\n",
+        "\n",
+        "All datasets have associated metadata -- properties shared by all the events in the dataset. In the ATLAS Open Data, metadata includes things like a unique numerical dataset identifier, the production cross section, and the description of the physics processes included in the sample. These metadata must be used to properly normalize the MC simulation datasets when comparing to detector data, and they can also be used to search for relevant or related samples.\n",
+        "\n",
+        "The metadata are available in a package called `atlasopenmagic` that is [available on pypi](http://pypi.org/project/atlasopenmagic/). Let's set it up and use it to explore the metadata of the most recent ATLAS Open Data release!\n",
+        "\n",
+        "Note that the metadata we will be looking at are also [available on the web](https://opendata.atlas.cern/docs/data/for_education/13TeV25_metadata) in a big table, but using a python module will make it much easier to grab numbers that you need for an analysis in an automatic way."
+      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "{'dataset_number': '345060',\n",
-       " 'physics_short': 'PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l',\n",
-       " 'e_tag': 'e7735',\n",
-       " 'cross_section_pb': 28.3,\n",
-       " 'genFiltEff': 0.000124,\n",
-       " 'kFactor': 1.717,\n",
-       " 'nEvents': 1598000,\n",
-       " 'sumOfWeights': 45231011.19517517,\n",
-       " 'sumOfWeightsSquared': 1296676130.5944173,\n",
-       " 'process': 'ggH H->ZZ->llll',\n",
-       " 'generator': 'Powheg+Pythia8(v.230)+EvtGen(v.1.6.0)',\n",
-       " 'keywords': ['Higgs', 'SM', 'SMHiggs', 'ZZ', 'mH125'],\n",
-       " 'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.noskim.root'],\n",
-       " 'description': '125 GeV',\n",
-       " 'job_path': 'https://gitlab.cern.ch/atlas-physics/pmg/infrastructure/mc15joboptions/-/tree/master/share/DSID345xxx/MC15.345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.py',\n",
-       " 'CoMEnergy': None,\n",
-       " 'GenEvents': None,\n",
-       " 'GenTune': None,\n",
-       " 'PDF': None,\n",
-       " 'Release': None,\n",
-       " 'Filters': None,\n",
-       " 'release': {'name': '2025e-13tev-beta'},\n",
-       " 'skims': [{'skim_type': '2J2LMET30',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2J2LMET30.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14667,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '1LMET30',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.1LMET30.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14668,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '3J1LMET30',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3J1LMET30.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14669,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': 'exactly4lep',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly4lep.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14670,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '2muons',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2muons.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14671,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '2to4lep',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2to4lep.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14672,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '4lep',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.4lep.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14673,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': 'exactly3lep',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly3lep.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14674,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': 'GamGam',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.GamGam.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14675,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '3lep',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3lep.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14676,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'},\n",
-       "  {'skim_type': '2bjets',\n",
-       "   'file_list': ['root://eospublic.cern.ch:1094//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2bjets70.root'],\n",
-       "   'description': None,\n",
-       "   'id': 14677,\n",
-       "   'dataset_number': '345060',\n",
-       "   'release_name': '2025e-13tev-beta'}]}"
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "572b491f",
+      "metadata": {
+        "id": "572b491f"
+      },
+      "outputs": [],
+      "source": [
+        "# First we install atlasopenmagic into our SWAN environment\n",
+        "# Notice that we need --user to avoid trying to install the package in a\n",
+        "# read-only file system This is a problem unique to SWAN; on binder or colab you\n",
+        "# won't need --user, but it doesn't hurt\n",
+        "%pip install --user atlasopenmagic"
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Now we can look at the metadata for a specific sample\n",
-    "atom.get_metadata(345060)\n",
-    "# Notice that the function here will accept either the dataset identifier or the \"physics short\", a short unique descriptor for the sample"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "504f4e2c",
-   "metadata": {},
-   "source": [
-    "That's a lot of metadata! Let's go through the fields a bit:\n",
-    "\n",
-    "* `dataset_number`: Unique identifier assigned to each dataset.\n",
-    "* `physics_short`: Short name with information regarding the content of the dataset.\n",
-    "* `cross_section_pb`: Represents the probability of a particular interaction occurring, measured in picobarns (pb). It is a fundamental parameter that helps understanding the likelihood of specific particle interactions under given conditions.\n",
-    "* `genFiltEff`: Measure of the effectiveness of the selection criteria applied to the data. It indicates the fraction of events that pass the filters applied during the data processing stages.\n",
-    "* `kFactor`: Multiplicative correction factor used to account for higher-order effects in theoretical calculations. It adjusts the leading-order theoretical predictions to better match the observed data by incorporating next-to-leading order (NLO) or next-to-next-to-leading order (NNLO) corrections.\n",
-    "* `nEvents`: Total count of the events in the (unskimmed) dataset.\n",
-    "* `sumOfWeights` (`sumOfWeightsSquared`): Sum of the event weights (or event weights squared) in the released dataset. Use this for normalization of the samples (for understanding the statistical power of the dataset).\n",
-    "* `generator`: Specifies the simulation software used to generate the data. Information about the generators can be found in the Simulation Tools section.\n",
-    "* `keywords`: Terms or phrases associated with the dataset that help to find specific datasets.\n",
-    "* `process`: Brief description of the physics process being studied. For instance, \"H->γγ\" denotes the Higgs boson decaying into two photons.\n",
-    "* `job_path`: Link to the specific code or configuration files used to generate the sample. Sometimes these will be fairly easy to understand; in some cases they are quite complex and difficult for non-experts to understand.\n",
-    "* `description`: Longer description of the process that was generated to create the sample.\n",
-    "* `e_tag`: ATLAS software configuration (including software version) that was used to create the sample.\n",
-    "* `file_list`: The list of paths for the unskimmed files in the dataset. \n",
-    "* `skims`: The list of metadata for the skimmed files in the dataset. Only one skimmed or unskimmed version should be used at a time. Within the skims we have:\n",
-    "   * A file list for the skim.\n",
-    "   * The name of the skim. The exact selections are [described here](https://opendata.atlas.cern/docs/data/for_education/13TeV25_details)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "7bcb845b",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "28.3\n"
-     ]
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0769168a",
+      "metadata": {
+        "id": "0769168a"
+      },
+      "outputs": [],
+      "source": [
+        "# Now we have to do a little bit of work to make sure that atlasopenmagic is\n",
+        "# available in our python path This is because SWAN by default does not include\n",
+        "# the local package installation area in the PYTHONPATH Again, this is not\n",
+        "# necessary on binder or colab - there you can remove these lines if you like,\n",
+        "# though they don't do any harm\n",
+        "import sys\n",
+        "import os\n",
+        "sys.path += [ f'{os.environ[\"HOME\"]}/.local/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages' ]\n",
+        "\n",
+        "# Now we can safely import atlasopenmagic\n",
+        "import atlasopenmagic as atom"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c229d2f2",
+      "metadata": {
+        "id": "c229d2f2"
+      },
+      "outputs": [],
+      "source": [
+        "# Now let's see what releases are available to us\n",
+        "atom.available_releases()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9f21e676",
+      "metadata": {
+        "id": "9f21e676"
+      },
+      "outputs": [],
+      "source": [
+        "# And let's use the latest release of Open Data for Outreach and Education\n",
+        "atom.set_release('2025e-13tev-beta')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bbb13de3",
+      "metadata": {
+        "id": "bbb13de3"
+      },
+      "outputs": [],
+      "source": [
+        "# Now we can look at the metadata for a specific sample\n",
+        "atom.get_metadata(345060)\n",
+        "# Notice that the function here will accept either the dataset identifier or the\n",
+        "# \"physics short\", a short unique descriptor for the sample %% [markdown] That's\n",
+        "# a lot of metadata! Let's go through the fields a bit:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "504f4e2c",
+      "metadata": {
+        "id": "504f4e2c"
+      },
+      "source": [
+        "That's a lot of metadata! Let's go through the fields a bit:\n",
+        "\n",
+        "* `dataset_number`: Unique identifier assigned to each dataset.\n",
+        "* `physics_short`: Short name with information regarding the content of the dataset.\n",
+        "* `cross_section_pb`: Represents the probability of a particular interaction occurring, measured in picobarns (pb). It is a fundamental parameter that helps understanding the likelihood of specific particle interactions under given conditions.\n",
+        "* `genFiltEff`: Measure of the effectiveness of the selection criteria applied to the data. It indicates the fraction of events that pass the filters applied during the data processing stages.\n",
+        "* `kFactor`: Multiplicative correction factor used to account for higher-order effects in theoretical calculations. It adjusts the leading-order theoretical predictions to better match the observed data by incorporating next-to-leading order (NLO) or next-to-next-to-leading order (NNLO) corrections.\n",
+        "* `nEvents`: Total count of the events in the (unskimmed) dataset.\n",
+        "* `sumOfWeights` (`sumOfWeightsSquared`): Sum of the event weights (or event weights squared) in the released dataset. Use this for normalization of the samples (for understanding the statistical power of the dataset).\n",
+        "* `generator`: Specifies the simulation software used to generate the data. Information about the generators can be found in the Simulation Tools section.\n",
+        "* `keywords`: Terms or phrases associated with the dataset that help to find specific datasets.\n",
+        "* `process`: Brief description of the physics process being studied. For instance, \"H->γγ\" denotes the Higgs boson decaying into two photons.\n",
+        "* `job_path`: Link to the specific code or configuration files used to generate the sample. Sometimes these will be fairly easy to understand; in some cases they are quite complex and difficult for non-experts to understand.\n",
+        "* `description`: Longer description of the process that was generated to create the sample.\n",
+        "* `e_tag`: ATLAS software configuration (including software version) that was used to create the sample.\n",
+        "* `file_list`: The list of paths for the unskimmed files in the dataset.\n",
+        "* `skims`: The list of metadata for the skimmed files in the dataset. Only one skimmed or unskimmed version should be used at a time. Within the skims we have:\n",
+        "   * A file list for the skim.\n",
+        "   * The name of the skim. The exact selections are [described here](https://opendata.atlas.cern/docs/data/for_education/13TeV25_details)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7bcb845b",
+      "metadata": {
+        "id": "7bcb845b"
+      },
+      "outputs": [],
+      "source": [
+        "# Get an individual field of metadata\n",
+        "xsec = atom.get_metadata('345060', 'cross_section_pb')\n",
+        "print(xsec)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1b70b245",
+      "metadata": {
+        "id": "1b70b245"
+      },
+      "outputs": [],
+      "source": [
+        "# Keywords are a great way to find datasets that you're interested in. Let's see\n",
+        "# what keywords are available.\n",
+        "atom.available_keywords()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "3eeade9a",
+      "metadata": {
+        "id": "3eeade9a"
+      },
+      "outputs": [],
+      "source": [
+        "# Now let's find datasets that match one of those keywords\n",
+        "atom.match_metadata(field='keywords',value='Higgs')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Now lets look for samples that have `W` somewhere in the process name\n",
+        "# Notice that this also catches things like `Wprime`!\n",
+        "atom.match_metadata(field='process',value='W')"
+      ],
+      "metadata": {
+        "id": "OR2mwg_tyUN-"
+      },
+      "id": "OR2mwg_tyUN-",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# We can also find samples that have a cross section near one we're interested in.\n",
+        "# By default, the matching is pretty tight (1%):\n",
+        "atom.match_metadata('cross_section_pb',0.001762)"
+      ],
+      "metadata": {
+        "id": "5FA68BEMykER"
+      },
+      "id": "5FA68BEMykER",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# But we can loosen the tolerance to 50% to see what other samples have similar\n",
+        "# cross sections.\n",
+        "atom.match_metadata('cross_section_pb',0.001762,float_tolerance=0.50)"
+      ],
+      "metadata": {
+        "id": "SZJfJxlJywO2"
+      },
+      "id": "SZJfJxlJywO2",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7ef6bcbe",
+      "metadata": {
+        "id": "7ef6bcbe"
+      },
+      "source": [
+        "The [atlasopenmagic documentation](https://pypi.org/project/atlasopenmagic/) has many more examples of searches; please feel free to play with the package yoourself, and [open an issue](https://github.com/atlas-outreach-data-tools/atlasopenmagic/issues) or a [pull request](https://github.com/atlas-outreach-data-tools/atlasopenmagic/pulls) if there is a feature that you would like to have available!"
+      ]
     }
-   ],
-   "source": [
-    "# Get an individual field of metadata\n",
-    "xsec = atom.get_metadata('345060', 'cross_section_pb')\n",
-    "print(xsec)"
-   ]
+  ],
+  "metadata": {
+    "@webio": {
+      "lastCommId": null,
+      "lastKernelId": null
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.9"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b70b245",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Keywords are a great way to find datasets that you're interested in. Let's see what keywords are available.\n",
-    "atom.available_keywords()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3eeade9a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Now let's find datasets that match one of those keywords\n",
-    "atom.match_metadata(field='keywords',value='Higgs')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7ef6bcbe",
-   "metadata": {},
-   "source": [
-    "The [atlasopenmagic documentation](https://pypi.org/project/atlasopenmagic/) has many more examples of searches; please feel free to play with the package yoourself, and [open an issue](https://github.com/atlas-outreach-data-tools/atlasopenmagic/issues) or a [pull request](https://github.com/atlas-outreach-data-tools/atlasopenmagic/pulls) if there is a feature that you would like to have available!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d80e33c7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "@webio": {
-   "lastCommId": null,
-   "lastKernelId": null
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
This adds a simple metadata tutorial that can run on any of our platforms, to show how to use atlasopenmagic and its search functionality. Might be close to what we want to use in the tutorial as well.