### PR TITLE
Open event generation notebook example

### DIFF
--- a/for-research/OpenEvgenTutorial.ipynb
+++ b/for-research/OpenEvgenTutorial.ipynb
@@ -16,7 +16,11 @@
     "We'll start by installing a couple of key packages using `pip`:\n",
     "* [atlasopenmagic](https://opendata.atlas.cern/docs/atlasopenmagic) provides convenient access to metadata and file locations\n",
     "* [pyhepmc](https://scikit-hep.org/pyhepmc/) provides convenient ways to play with HEPMC files\n",
-    "* [graphviz](https://pypi.org/project/graphviz/) provides cool visualization interfaces for the events"
+    "* [graphviz](https://pypi.org/project/graphviz/) provides cool visualization interfaces for the events\n",
+    "\n",
+    "For the last section of this notebook, we'll use a parametric detector simulation called [Delphes](http://delphes.github.io). It's commonly used for phenomenology studies, and has a lot of nice features that we'll only just touch here, but you should feel free to explore further on your own!\n",
+    "\n",
+    "As you'll see in the log, it may be that you need to restart the kernel after installing these packages for the first time in order to get everything in working order. In case you encounter some odd error (cannot import a module, or cannot find a package) later in this notebook, try restarting the kernel to see if that solves your issue."
    ]
   },
   {
@@ -29,7 +33,10 @@
    },
    "outputs": [],
    "source": [
-    "%pip install atlasopenmagic pyhepmc graphviz"
+    "# Pip installs first\n",
+    "%pip install atlasopenmagic pyhepmc graphviz\n",
+    "# Now conda installs\n",
+    "%conda install --channel conda-forge delphes"
    ]
   },
   {
@@ -193,7 +200,8 @@
     "\n",
     "We'll be able to see the incoming protons, as well as various particles involved in\n",
     "the collision. Notice that the two incoming protons in the collision are *not*\n",
-    "necessarily the first and second particles in the event! Any analysis of these\n",
+    "necessarily the first and second particles in the event! In this particular case,\n",
+    "they're the first and 11th! Any analysis of these kinds of\n",
     "events always takes a bit of care, because the event records might not look the way\n",
     "you would naively expect. It's always good to check your assumptions carefully."
    ]
@@ -214,6 +222,109 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3e7d36db-b1a6-4009-8825-3614228e0b07",
+   "metadata": {},
+   "source": [
+    "Now let's look at some of the vertices. A vertex can often be thought of as representing a single interaction, like the decay of a particle. Here's a simple little function that will print the vertex information in a reasonably pretty way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4061fd40-cc45-4bf1-8da1-7dbf48765928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function to print vertices and their incoming and outgoing particles\n",
+    "def print_vertex(event, vertex_number):\n",
+    "    print(f'Vertex {vertex_number}: {event.vertices[vertex_number]}')\n",
+    "    print('Incoming particle list:')\n",
+    "    for n,p in enumerate(event.vertices[vertex_number].particles_in):\n",
+    "        print(f'   Particle {n}: {p}')\n",
+    "    print('Outgoing particle list:')\n",
+    "    for n,p in enumerate(event.vertices[vertex_number].particles_out):\n",
+    "        print(f'   Particle {n}: {p}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b74118-c500-48fc-bbd1-541fb0c2a420",
+   "metadata": {},
+   "source": [
+    "Vertices have a time and position, and particles have a momentum, energy, mass, particle ID (`pid`) and status. The particle ID is standardized across all generators; a group called the Particle Data Group keeps a [review explaining and listing particle IDs](http://pdg.lbl.gov/2024/reviews/rpp2024-rev-monte-carlo-numbering.pdf). Because the event generator used to create these events is Pythia8, we can look into the [Pythia8 documentation](https://pythia.org/latest-manual/ParticleProperties.html) to see what status codes it uses. Only a few status codes are standard across all generators:\n",
+    "- Status code 1 means \"stable particle\"; that propagation of that particle through the detector should be simulated.\n",
+    "- Status code 2 means \"particle decayed\"; there will be decay products that the generator (Pythia8 in this case) created.\n",
+    "- Status code 3 means \"documentation particle\"; these are entires in the event record that the authors wanted to keep to help document what happened in the event, but they should not necessarily be considered part of any kind of physical event interpretation.\n",
+    "\n",
+    "There are _many_ other status codes used in some generators like Pythia. \n",
+    "\n",
+    "For educational purposes we've picked out a few interesting vertices from the first event in the file this notebook uses by default. In case you load a different file or dataset, you might find different vertex properties or numbers of vertices. First, let's look at vertex number 465."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ffe622f-42dd-4930-9754-4104164cc00b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_vertex(my_first_event,465)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f074366c-443e-441d-8982-0e39cf4b6ea1",
+   "metadata": {},
+   "source": [
+    "That's a nice example of a decay vertex. You can look up the `pid` mapping in the Particle Data Group guide; this particular vertex has a $K^*\\rightarrow K^+\\pi^-$ decay (notice that the negative `pid` means that it has the opposite charge from what's listed in the Particle Data Group table). You can see that the $K^*$ has `status=2`, meaning it decays, and both the $K^+$ and $\\pi^-$ have `status=1`, meaning that they are stable and will fly into the detector.\n",
+    "\n",
+    "Next, let's look at vertex number 100."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ee2430-231b-4449-9937-143e2bca7d76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_vertex(my_first_event,100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "111a42e7-0414-4eaa-8a8e-88e7d3fbece3",
+   "metadata": {},
+   "source": [
+    "That's an interesting looking vertex - only one particle in, and one particle out! In this case, the status code of the particle changed, from 62 to 71. We can see in the Pythia8 documentation that these are two different representations of the same particle; in the second case the particle is being prepared for \"hadronization\" (the process of taking all the particles like quarks and gluons that are produced in the original collision and turning them into the hadrons that we observe in our detectors). This is another reason that looking through these event records is tricky: sometimes we are looking at different views of the same particle, and not all of them are really \"physical\".\n",
+    "\n",
+    "Finally, let's look at vertex number 327."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aed943fe-27ea-42a4-903e-8b7f2c2a9c8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_vertex(my_first_event,327)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5ab6c8f-9e50-47c3-a41f-e724f737fc9c",
+   "metadata": {},
+   "source": [
+    "Wow, that's a weird looking vertex! This is an example of a hadronization vertex, where some of the particles that were produced in the original collision have been gathered together to form hadrons. You can see that some of those hadrons are stable, and some of them decay before they reach the detector. \n",
+    "\n",
+    "In our minds, we often have a simplified view of an event generator record as a tree, where one particle becomes two, and two become four, as they produce radiation and decay. The above examples show us that things can be a lot more complicated than that, and considerable care is required when studying the internals of the particle records. It's usually safest to look at the stable particles (with `status=1`), because those are the particles that the generator believes will enter the detector. They are what we refer to as \"observable\". Often when trying to look into things that are not observable (e.g. particles with other status codes), the answer becomes dependent on the implementation of the event generator, or what the event generator authors chose to write into the HEPMC record — and of course, nature can't depend on what an event generator author decided to do!\n",
+    "\n",
+    "Feel free to look at other particles or vertices, or records from other events if you would like."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "af9060e8-6eb6-4951-acad-4d3387616f68",
    "metadata": {},
    "source": [
@@ -228,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "OR2mwg_tyUN-",
    "metadata": {
     "id": "OR2mwg_tyUN-",
@@ -264,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "5FA68BEMykER",
    "metadata": {
     "id": "5FA68BEMykER",
@@ -306,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "SZJfJxlJywO2",
    "metadata": {
     "id": "SZJfJxlJywO2",
@@ -358,29 +469,9 @@
    "source": [
     "## Detector Simulation\n",
     "\n",
-    "We can do some simple detector simulation using [Delphes](https://github.com/delphes/delphes) as well. Delphes is a pretty standard parametric detector simulation package used widely in the phenomenology community. The first thing we have to do is install it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b223ec96-7e72-4eb4-b081-78187cd66f99",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%conda install --channel conda-forge delphes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0959961d-9850-4a5e-9315-225177763ac4",
-   "metadata": {},
-   "source": [
-    "Delphes offers some command-line executables that can be used. We will run one of the pre-defined analyses as an example. Of course, more complicated usage is possible!\n",
+    "We can do some simple detector simulation using [Delphes](https://github.com/delphes/delphes) as well. Delphes is a pretty standard parametric detector simulation package used widely in the phenomenology community. Delphes offers some command-line executables that can be used. We will run one of the pre-defined analyses as an example. Of course, more complicated usage is possible!\n",
     "\n",
-    "Notice that we are passing the HEPMC file name through bash magic here."
+    "There's a fair bit of magic in the next line. First, we're using `%%bash` magic in jupyter to let us run a command like we had a terminal with a `bash` shell. Delphes doesn't have a python interface, so we have to use it like an executable. Notice that we are passing the HEPMC file name through the bash magic here. The actual executable we are running is called `DelphesHepMC2`. Since these open event generation files are in `HepMC2` text format, that's the right executable to use. We access the \"cards\", which are for configuration, using the environment variable `${CONDA_PREFIX}`. That's where they all get installed, because we used conda up at the top of this notebook to install Delphes. There are a [lot of cards](https://github.com/delphes/delphes/tree/master/cards) available; here we're using the default ATLAS card. The next two arguments are the output file name (`delphes_output.root`) and the input file name (`$1` refers back to the HEPMC file name that we passed via the bash magic)."
    ]
   },
   {


### PR DESCRIPTION
### Summary

Until now, we were missing an example of usage of the event generation open data. This adds a notebook with a few examples of using those open data. Should help @Soap2G with his presentation next week (and me with mine in 3 weeks).

### List of changes proposed in this PR (pull-request)

* New open evgen notebook featuring the use of `pyhepmc` to make some simple graphs of events, and to loop through the HEPMC events and make a couple of histograms. We also install and run Delphes as a simple parametric detector simulation and play with the output of that. This has been tested on binder and is working great. On Colab graphviz doesn't do the things I want, so I'd just focus on binder for the time being for this one.

### What should a reviewer concentrate their feedback on?

Totally new notebook! 

- [x] Documentation looks ok? Explanations are clear?
- [x] Saved output seems ok and agrees with our standards?