### PR TITLE
Fix removed pandas DataFrame.append() in ttZ_ML_from_root notebook

### DIFF
--- a/13-TeV-examples/uproot_python/ttZ_ML_from_root.ipynb
+++ b/13-TeV-examples/uproot_python/ttZ_ML_from_root.ipynb
@@ -2771,8 +2771,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_6j2b_CR['Other'] = data_6j2b_CR['Other'].append(data_6j2b_CR['Z']) # append Z events to Other\n",
-    "data_6j2b_CR['Other'] = data_6j2b_CR['Other'].append(data_6j2b_CR[r'$t\\bar{t}Z$']) # append ttZ events to Other"
+    "data_6j2b_CR['Other'] = pd.concat([data_6j2b_CR['Other'], data_6j2b_CR['Z']]) # append Z events to Other\n",
+    "data_6j2b_CR['Other'] = pd.concat([data_6j2b_CR['Other'], data_6j2b_CR[r'$t\\bar{t}Z$']]) # append ttZ events to Other"
    ]
   },
   {
@@ -2921,8 +2921,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_5j2b_CR['Other'] = data_5j2b_CR['Other'].append(data_5j2b_CR['Z']) # append Z events to Other\n",
-    "data_5j2b_CR['Other'] = data_5j2b_CR['Other'].append(data_5j2b_CR[r'$t\\bar{t}Z$']) # append ttZ events to Other"
+    "data_5j2b_CR['Other'] = pd.concat([data_5j2b_CR['Other'], data_5j2b_CR['Z']]) # append Z events to Other\n",
+    "data_5j2b_CR['Other'] = pd.concat([data_5j2b_CR['Other'], data_5j2b_CR[r'$t\\bar{t}Z$']]) # append ttZ events to Other"
    ]
   },
   {
@@ -3071,8 +3071,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_6j1b_CR['Other'] = data_6j1b_CR['Other'].append(data_6j1b_CR['Z']) # append Z events to Other\n",
-    "data_6j1b_CR['Other'] = data_6j1b_CR['Other'].append(data_6j1b_CR[r'$t\\bar{t}Z$']) # append ttZ events to Other"
+    "data_6j1b_CR['Other'] = pd.concat([data_6j1b_CR['Other'], data_6j1b_CR['Z']]) # append Z events to Other\n",
+    "data_6j1b_CR['Other'] = pd.concat([data_6j1b_CR['Other'], data_6j1b_CR[r'$t\\bar{t}Z$']]) # append ttZ events to Other"
    ]
   },
   {


### PR DESCRIPTION
## What

`ttZ_ML_from_root.ipynb` builds its "Other" control-region background with six `DataFrame.append()` calls. pandas **2.0** removed `DataFrame.append()` / `Series.append()` in favour of `pandas.concat()` ([GH 35407](https://github.com/pandas-dev/pandas/issues/35407)), and `pyproject.toml` pins `pandas>=2.2.2` — so these cells raise `AttributeError: 'DataFrame' object has no attribute 'append'` on the project's own dependency set. The notebook is currently marked ❌ on the [status page](https://opendata.atlas.cern/docs/status).

## Change

Replace each `df = df.append(other)` with the documented equivalent `df = pd.concat([df, other])`, in the 6j2b / 5j2b / 6j1b control regions:

```python
- data_6j2b_CR['Other'] = data_6j2b_CR['Other'].append(data_6j2b_CR['Z'])
+ data_6j2b_CR['Other'] = pd.concat([data_6j2b_CR['Other'], data_6j2b_CR['Z']])
```

`pandas` is already imported as `pd`. `concat`'s default index handling matches the old `append` (no `ignore_index`), so the resulting frames — and therefore the downstream plots and data-driven estimates — are unchanged. Only those 6 lines are touched.

## Scope

Focused on the removed-API breakage only. A repo-wide scan found no other genuine `DataFrame.append` / `Series.append` usage (the remaining `.append` calls are `list` / `np.append`). This clears one definite blocker; I haven't executed the full notebook end-to-end against live data, so I'm not claiming it's the only fix needed for a green status — just that it removes a hard pandas-2.0 failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
